### PR TITLE
Add some text about email addresses

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@ but this often does not integrate well with email provider systems.
 This is an option not available in any offline contexts
 where people are asked to supply an email address.
 
-Furthermore, some sites refuse to do business
+Some sites refuse to do business
 with people who choose to supply email aliases,
 citing a higher risk of abuse.
 Finding technical solutions that allow businesses

--- a/index.html
+++ b/index.html
@@ -147,13 +147,13 @@ one of the most shameful aspects of the web is how it has allowed sites to surve
 Sites take what they learn about the people that visit them
 and treat that information as a commodity to be sold or exchanged.
 
-The TAG has long regarded [unsanctioned tracking as unacceptable](https://www.w3.org/2001/tag/doc/unsanctioned-tracking/)
+The TAG has long regarded unsanctioned tracking as unacceptable ([[UNSANCTIONED-TRACKING]])
 and has advocated for technical measures that curtail these practices.
 Notably, [the TAG unequivocally condemned cross-site cookies and called for browsers to disable them](https://www.w3.org/2001/tag/doc/web-without-3p-cookies/).
 Positive trends from browsers in recent years include a range of other technical measures,
-including reductions in fingerprinting, state partitioning, and [navigation tracking mitigations](https://privacycg.github.io/nav-tracking-mitigations/).
+including reductions in fingerprinting, state partitioning, and navigation tracking mitigations ([[NAV-TRACKING-MITIGATIONS]]).
 
-These technical measures are consistent with the TAG's [documented principles for privacy](https://w3ctag.github.io/privacy-principles/).
+These technical measures are consistent with the TAG's documented principles for privacy ([[PRIVACY-PRINCIPLES]]).
 These principles articulate why privacy is essential to maintaining personal autonomy.
 The same high-level principles are shared
 by the many jurisdictions that have implemented data protection legislation.
@@ -323,8 +323,9 @@ that provides strong unlinkability.
 
 A business might request an email address for different reasons.
 
-Superficially, someone sharing their email address
+Someone sharing their email address
 gives sites the ability to communicate with that person at a later time.
+This might be the reason given to ask for email.
 
 In addition to enabling communication,
 an email address is also an identifier.
@@ -333,7 +334,8 @@ also allows the recipient to match that email address
 with other places that the person shared the same email address.
 The use of email addresses therefore enables tracking and profiling people.
 
-Tracking activity and assembling profiles could be used
+Though generally unacceptable ([[UNSANCTIONED-TRACKING]]),
+tracking activity and assembling profiles could be used
 to mitigate against the risk of abuse.
 Understanding that a person has a history of honest engagement
 with other businesses is valuable to a website,

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script
       defer
       class="remove"
-      src="https://www.w3.org/Tools/respec/respec-w3c">  
+      src="https://www.w3.org/Tools/respec/respec-w3c">
     </script>
     <script class="remove">
 var respecConfig = {
@@ -214,7 +214,7 @@ However, it does not eliminate the need for scrutiny,
 particularly with regard to proportionality of use,
 user control, and the risk of such mechanisms becoming normalized across the web.
 Nevertheless, we recommend that the specification authors look to such mechanisms as a guide for mitigating
-potential harms in this area. 
+potential harms in this area.
 
 ### Case Study: Aadhaar
 
@@ -249,10 +249,10 @@ its use was widespread in employment and other non-government interactions.
 Centralisation of trust can lead to a fragmented web, where access depends on which authorities
 a site or user is willing, or able, to work with.
 
-This risks excluding marginalized people. 
+This risks excluding marginalized people.
 For example, a visitor, migrant, or refugee may not be able to, or may not feel safe to, use credentials
-from their country of origin. 
-Especially where major platforms only recognize a narrow set of issuers, 
+from their country of origin.
+Especially where major platforms only recognize a narrow set of issuers,
 or only recognize issuers tied to a specific jurisdiction.
 The choice of jurisdiction is not often something that a user can choose,
 but instead one dictated by factors outside of their control.
@@ -304,13 +304,8 @@ that all users are equally able to produce a credential.
 ## Use Cases and Technical Options
 
 A better understanding of why sites seek to obtain and use identity is necessary.
-While the universality of a generic solution is appealing,
-each use case could depend on providing different sorts of information.
-
-[... need to have more on use cases in here ...]
-
-Each use case might require a different type of solution.
-Different solutions can have dramatically different privacy characteristics.
+Use cases justify approaches,
+each of which has very different privacy characteristics.
 
 For example,
 a [data minimization](https://w3ctag.github.io/privacy-principles/#data-minimization) approach might favor the use of selective disclosure,
@@ -323,6 +318,49 @@ such as a system to authorize access to online gambling,
 something that might be restricted by age or past history of susceptibility--
 might be best suited to a zero-knowledge system
 that provides strong unlinkability.
+
+### Use Case: Email Addresses
+
+A business might request an email address for different reasons.
+
+Superficially, someone sharing their email address
+gives sites the ability to communicate with that person at a later time.
+
+In addition to enabling communication,
+an email address is also an identifier.
+Asking a person for an email address
+also allows the recipient to match that email address
+with other places that the person shared the same email address.
+The use of email addresses therefore enables tracking and profiling people.
+
+Tracking activity and assembling profiles could be used
+to mitigate against the risk of abuse.
+Understanding that a person has a history of honest engagement
+with other businesses is valuable to a website,
+particularly where their own engagement with that person
+entails some amount of risk.
+
+This combination of purposes can be managed through the use of email aliases:
+alternative addresses for the same person that deliver to the same mailbox.
+These prevent the assembly of activity profiles
+because a fresh email address is provided for each context.
+
+Email aliases separate out the right to communicate from the right to identify.
+The challenge is that it needs to be easy to supply email aliases,
+something that is not well-supported.
+Integration with web form autofill can help people use this capability,
+but this often does not integrate well with email provider systems.
+This is an option not available in any offline contexts
+where people are asked to supply an email address.
+
+Furthermore, some sites refuse to do business
+with people who choose to supply email aliases,
+citing a higher risk of abuse.
+Finding technical solutions that allow businesses
+to affray these risks
+without enabling tracking or the creation of profiles
+is something that needs more research.
+
 
 ## Identity For Whom
 


### PR DESCRIPTION
This is a start on sections about common identities and the challenges involved with providing privacy.  Phone numbers come next and I plan to be even more pointed about those as a terrible idea.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/web-no-papers/pull/3.html" title="Last updated on Jun 19, 2025, 7:15 AM UTC (b21a7bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/web-no-papers/3/ad5c00a...b21a7bb.html" title="Last updated on Jun 19, 2025, 7:15 AM UTC (b21a7bb)">Diff</a>