### PR TITLE
Add a more thorough treatment of statelessness

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,8 +456,8 @@ potential harms in this area.
 
 ### Improving Inclusion
 
-The exlusion risk to people
-who might be unable to obtain a credential ([[[#central-trust]]])
+The exclusion risk to people
+who might be unable to obtain a credential (see [[[#central-trust]]])
 is not always a problem that needs to be addressed through system design.
 For instance,
 when interacting with a government


### PR DESCRIPTION
This is more than @toreini added in #26, but I realize that this is an important point and one that can be subject to technical measures. The real challenge here is governance of any such system, but it is possible to remove choice when it comes to the use of digital credentials around certain traits.  If the point of the credential is to do things like establish basic traits, like name, birthdate, or that this is a human being, it should not matter who makes this assertion.

Closes #23.  Though I did not expect to be fixing that, this seems to have worked out.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/web-no-papers/pull/34.html" title="Last updated on Aug 27, 2025, 5:32 AM UTC (434f1b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/web-no-papers/34/b4c7616...434f1b3.html" title="Last updated on Aug 27, 2025, 5:32 AM UTC (434f1b3)">Diff</a>